### PR TITLE
feat: 50音順一覧オーバーレイ機能追加

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -25,11 +25,28 @@
           class="search-input"
           placeholder="タイトル、説明、レビューコメントで検索..."
         />
+        <!-- 50音順一覧トグルボタンを追加 -->
+        <button id="gameListToggle" class="list-toggle-btn" type="button">
+          📋 50音順一覧
+        </button>
       </section>
 
       <main id="gamesContainer" class="games-container">
         <div class="loading">読み込み中...</div>
       </main>
+    </div>
+
+    <!-- 50音順一覧オーバーレイを追加 -->
+    <div id="gameListOverlay" class="game-list-overlay hidden">
+      <div class="game-list-container">
+        <div class="game-list-header">
+          <h2 class="game-list-title">📋 ゲーム一覧（50音順）</h2>
+          <button id="gameListClose" class="close-btn" type="button">✕</button>
+        </div>
+        <div id="gameListContent" class="game-list-content">
+          <div class="loading">読み込み中...</div>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,6 +4,7 @@ import "./styles.css";
 class FamicomSearchApp {
   constructor() {
     this.games = [];
+    this.sortedGames = [];
     this.init();
   }
 
@@ -19,7 +20,9 @@ class FamicomSearchApp {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       this.games = await response.json();
+      this.sortedGames = this.sortGamesByJapanese(this.games);
       this.renderGames(this.games);
+      this.renderGameList();
     } catch (error) {
       console.error("データ読み込み失敗:", error);
       this.showError("データの読み込みに失敗しました");
@@ -29,6 +32,117 @@ class FamicomSearchApp {
   setupEventListeners() {
     const searchInput = document.getElementById("searchInput");
     searchInput.addEventListener("input", () => this.handleSearch());
+
+    // 50音順一覧関連のイベントリスナーを追加
+    const listToggle = document.getElementById("gameListToggle");
+    const listClose = document.getElementById("gameListClose");
+    const overlay = document.getElementById("gameListOverlay");
+
+    listToggle.addEventListener("click", () => this.toggleGameList());
+    listClose.addEventListener("click", () => this.hideGameList());
+
+    // オーバーレイ背景クリックで閉じる
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) {
+        this.hideGameList();
+      }
+    });
+
+    // ESCキーで閉じる
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        this.hideGameList();
+      }
+    });
+  }
+
+  // 50音順ソート関数
+  sortGamesByJapanese(games) {
+    return [...games].sort((a, b) => {
+      return a.title.localeCompare(b.title, "ja", { numeric: true });
+    });
+  }
+
+  // 50音順一覧の表示/非表示切り替え
+  toggleGameList() {
+    const overlay = document.getElementById("gameListOverlay");
+    if (overlay.classList.contains("hidden")) {
+      this.showGameList();
+    } else {
+      this.hideGameList();
+    }
+  }
+
+  showGameList() {
+    const overlay = document.getElementById("gameListOverlay");
+    overlay.classList.remove("hidden");
+    document.body.style.overflow = "hidden"; // 背景スクロール防止
+  }
+
+  hideGameList() {
+    const overlay = document.getElementById("gameListOverlay");
+    overlay.classList.add("hidden");
+    document.body.style.overflow = ""; // スクロール復元
+  }
+
+  // 50音順一覧のレンダリング
+  renderGameList() {
+    const container = document.getElementById("gameListContent");
+
+    if (this.sortedGames.length === 0) {
+      container.innerHTML =
+        '<div class="loading">ゲームデータがありません</div>';
+      return;
+    }
+
+    const gamesHtml = this.sortedGames
+      .map(
+        (game, index) => `
+      <div class="game-list-item" data-game-index="${index}">
+        <div class="game-list-item-content">
+          <div class="game-list-item-title">${game.title}</div>
+          <div class="game-list-item-meta">${game.publisher} · ${game.releaseYear}年 · ${game.genre}</div>
+        </div>
+      </div>
+    `
+      )
+      .join("");
+
+    container.innerHTML = gamesHtml;
+
+    // 一覧アイテムクリックでメイン画面にスクロール
+    container.addEventListener("click", (e) => {
+      const item = e.target.closest(".game-list-item");
+      if (item) {
+        const gameIndex = parseInt(item.dataset.gameIndex);
+        const game = this.sortedGames[gameIndex];
+        this.scrollToGame(game);
+        this.hideGameList();
+      }
+    });
+  }
+
+  // 指定ゲームまでスクロール
+  scrollToGame(targetGame) {
+    const gameCards = document.querySelectorAll(".game");
+    for (const card of gameCards) {
+      const titleElement = card.querySelector(".game-title-link");
+      if (
+        titleElement &&
+        titleElement.textContent.trim() === targetGame.title
+      ) {
+        card.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
+        // ハイライト効果を追加
+        card.style.border = "2px solid #0969da";
+        setTimeout(() => {
+          card.style.border = "1px solid #d1d9e0";
+        }, 2000);
+        break;
+      }
+    }
   }
 
   handleSearch() {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -48,10 +48,13 @@ body {
 /* 検索セクション */
 .search-section {
   margin-bottom: 24px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
 }
 
 .search-input {
-  width: 100%;
+  flex: 1;
   padding: 12px 16px;
   font-size: 16px;
   font-family: inherit;
@@ -69,6 +72,141 @@ body {
 }
 
 .search-input::placeholder {
+  color: #656d76;
+}
+
+/* 50音順一覧トグルボタン */
+.list-toggle-btn {
+  padding: 12px 16px;
+  font-size: 14px;
+  font-family: inherit;
+  background-color: #f6f8fa;
+  color: #24292f;
+  border: 1px solid #d1d9e0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.list-toggle-btn:hover {
+  background-color: #eaeef2;
+  border-color: #0969da;
+}
+
+.list-toggle-btn:active {
+  background-color: #dde4ed;
+}
+
+/* 50音順一覧オーバーレイ */
+.game-list-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+}
+
+.game-list-container {
+  width: 400px;
+  max-width: 90vw;
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-left: 1px solid #d1d9e0;
+  display: flex;
+  flex-direction: column;
+  animation: slideInRight 0.3s ease-out;
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.game-list-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid #d1d9e0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: rgba(246, 248, 250, 0.8);
+}
+
+.game-list-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #24292f;
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  color: #656d76;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.close-btn:hover {
+  background-color: rgba(208, 215, 222, 0.3);
+  color: #24292f;
+}
+
+.game-list-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+}
+
+/* ゲーム一覧アイテム */
+.game-list-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(208, 215, 222, 0.3);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.game-list-item:hover {
+  background-color: rgba(9, 105, 218, 0.05);
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-left: -8px;
+  margin-right: -8px;
+  border-radius: 6px;
+}
+
+.game-list-item:last-child {
+  border-bottom: none;
+}
+
+.game-list-item-content {
+  flex: 1;
+}
+
+.game-list-item-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #0969da;
+  margin-bottom: 2px;
+}
+
+.game-list-item-meta {
+  font-size: 12px;
   color: #656d76;
 }
 
@@ -315,6 +453,20 @@ body {
 
   .title {
     font-size: 2rem;
+  }
+
+  .search-section {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .list-toggle-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .game-list-container {
+    width: 100vw;
   }
 
   .game {


### PR DESCRIPTION
新機能:
- 右側400px幅の透過オーバーレイパネル
- ゲームタイトル50音順ソート表示 
- 一覧アイテムクリックでメイン画面連動スクロール
- ハイライト効果付きスムーズナビゲーション

UX改善:
- backdrop-filter + rgba(255,255,255,0.95)透過効果
- 右スライドインアニメーション (slideInRight)
- ESC/背景クリック/×ボタンでの直感的クローズ操作
- 背景スクロール防止

レスポンシブ:
- デスクトップ: 右側パネル表示
- モバイル: 全幅オーバーレイ表示